### PR TITLE
Use a more predictable response code for invalid user

### DIFF
--- a/source/ftpSession.cpp
+++ b/source/ftpSession.cpp
@@ -2743,7 +2743,7 @@ void FtpSession::USER (char const *args_)
 		return;
 	}
 
-	sendResponse ("502 Invalid user\r\n");
+	sendResponse ("430 Invalid user\r\n");
 }
 
 // clang-format off


### PR DESCRIPTION
`430` is more commonly used to signify bad auth, while `502` is generally restricted to responses to non-implemented commands. `430` is already [used](https://github.com/mtheall/ftpd/blob/9f86715a4999fcec355162767832c5bb48e229fc/source/ftpSession.cpp#L2163) [twice](https://github.com/mtheall/ftpd/blob/9f86715a4999fcec355162767832c5bb48e229fc/source/ftpSession.cpp#L2174) in `PASS` and it'd make sense to use it here as well.