### PR TITLE
Fix DkScissor calculation

### DIFF
--- a/source/switch/imgui_deko3d.cpp
+++ b/source/switch/imgui_deko3d.cpp
@@ -484,7 +484,7 @@ void imgui::deko3d::render (dk::UniqueDevice &device_,
 				if (clip.z > width)
 					clip.z = width;
 				if (clip.w > height)
-					clip.z = height;
+					clip.w = height;
 
 				// apply scissor boundaries
 				cmdBuf_.setScissors (


### PR DESCRIPTION
Previously this would clip Modal window backgrounds:
![2022081212201200-6C53F6F49C292FD1C2157D3E0D773577](https://user-images.githubusercontent.com/45773016/184336034-0810d53d-9612-414d-ab3e-e3f351b31e1e.jpg)

To dim the entire framebuffer ImGui submits a draw cmd with clip (-1,-1), (width+1,height+1), which triggers this bug.