### PR TITLE
Updates Switch app initialization to disable auto-sleep

### DIFF
--- a/source/switch/init.c
+++ b/source/switch/init.c
@@ -53,6 +53,8 @@ void userAppInit ()
 {
 	// disable immediate app close
 	appletLockExit ();
+	// disable auto-sleep
+	appletSetAutoSleepDisabled (true);
 
 	romfsInit ();
 	plInitialize (PlServiceType_User);
@@ -80,5 +82,7 @@ void userAppExit ()
 	psmExit ();
 	plExit ();
 	romfsExit ();
+	// Restore auto-sleep
+	appletSetAutoSleepDisabled (false);
 	appletUnlockExit ();
 }


### PR DESCRIPTION
Disables HOS auto-sleep during app lifetime to prevent sleep mode from breaking large file transfers. Disabling sleep is a sane default behavior as it's very easy to break file transfers with common HOS auto-sleep timeout settings.

See: #149 #157 