### PR TITLE
[NDS] Fix uninitialized background tiles

### DIFF
--- a/source/nds/platform.cpp
+++ b/source/nds/platform.cpp
@@ -101,6 +101,9 @@ bool platform::init ()
 	vramSetBankA (VRAM_A_MAIN_BG);
 	vramSetBankC (VRAM_C_SUB_BG);
 
+	std::memset (BG_MAP_RAM (4), 0, 0x1000);
+	std::memset (BG_MAP_RAM_SUB (4), 0, 0x1000);
+
 	consoleInit (&g_statusConsole, 0, BgType_Text4bpp, BgSize_T_256x256, 4, 0, true, true);
 	g_logConsole = g_statusConsole;
 	consoleInit (&g_sessionConsole, 0, BgType_Text4bpp, BgSize_T_256x256, 4, 0, false, true);


### PR DESCRIPTION
On Nintendo DS, the rendering code alternates between two background map blocks. However, both map blocks are not guaranteed to be initialized before being displayed, which can expose uninitialized VRAM as corrupted tiles behind the console text.

This change keeps the existing background-map double buffering and DMA copy logic, while zero-initializing map blocks 4 and 5 for both the main and sub backgrounds during `platform::init()` before `consoleInit()`.

This ensures that either map block is initialized before it can become visible, while preserving the double buffering used to avoid partially-drawn tiles during high-frequency text updates.

Hardware retest pending on a Nintendo DS Lite with an R4 flashcard and TWiLight Menu++.